### PR TITLE
Update template.py

### DIFF
--- a/custom_components/oref_alert/template.py
+++ b/custom_components/oref_alert/template.py
@@ -12,9 +12,8 @@ from homeassistant.helpers.template import (
     Template,
     TemplateEnvironment,
 )
-from homeassistant.helpers.template import (
-    distance as distance_func,
-)
+
+from homeassistant.util.location import distance as distance_func
 
 from .categories import category_to_emoji, category_to_icon
 from .const import (


### PR DESCRIPTION
שגיאה בעדכון בטא של 2026.5
הפונקציה distance פשוט לא קיימת יותר תחת homeassistant.helpers.template.

from homeassistant.helpers.template import (
    distance as distance_func,
)